### PR TITLE
Update gptwol volume mapping for new database format

### DIFF
--- a/compose/gptwol.yml
+++ b/compose/gptwol.yml
@@ -18,6 +18,6 @@ services:
       - REFRESH_PING=60 # in seconds
       # - PING_TIMEOUT=200 # in milliseconds
     volumes:
-      - $DOCKERDIR/appdata/gptwol/computers.txt:/app/computers.txt
+      - $DOCKERDIR/appdata/gptwol/db:/app/db
       - $DOCKERDIR/appdata/gptwol/cron:/etc/cron.d      
     # DOCKER-LABELS-PLACEHOLDER


### PR DESCRIPTION
## Description
Updates the gptwol volume mapping to use the new database format.

## Changes
- Changed volume mapping from `computers.txt` file to `db` directory
- Resolves migration warnings in gptwol application

## Note
This change assumes that Deployrr's deployment process will create the `appdata/gptwol/db` directory automatically. If not, users may need to create this directory manually before deploying.

## Testing
Tested with gptwol container and confirmed migration warning is resolved.