### PR TITLE
Fix PostgreSQL v18+ data persistence issue with correct volume mount

### DIFF
--- a/compose/postgresql.yml
+++ b/compose/postgresql.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "$POSTGRESQL_PORT:5432"
     volumes:
-      - $DOCKERDIR/appdata/postgresql:/var/lib/postgresql/18/data
+      - $DOCKERDIR/appdata/postgresql:/var/lib/postgresql
     environment:
       # - POSTGRES_DB=$POSTGRES_DB
       - POSTGRES_USER=$POSTGRES_USER


### PR DESCRIPTION
  Description:
  ## Problem
  PostgreSQL 18+ introduced a breaking change where the default PGDATA location changed from `/var/lib/postgresql/data` to `/var/lib/postgresql/18/docker`. The current volume mount path causes data to be stored in anonymous Docker volumes that are lost on container restarts.

  ## Solution
  Updated the volume mount from:
  - `/var/lib/postgresql/18/data`

  To:
  - `/var/lib/postgresql`

  This parent directory approach:
  - Aligns with PostgreSQL 18's new default behavior
  - Prevents data loss on container restarts
  - Is future-proof for major version upgrades
  - Recommended by PostgreSQL community best practices

  ## Testing
  - ✓ Verified data persists across container restarts
  - ✓ No anonymous volumes created
  - ✓ Databases remain intact after container recreation

  ## Reference
  https://aronschueler.de/blog/2025/10/30/fixing-postgres-18-docker-compose-startup/