### PR TITLE
fix: restore issue templates to v6

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_request.yml
+++ b/.github/ISSUE_TEMPLATE/app_request.yml
@@ -1,0 +1,68 @@
+name: "📦 App Request"
+description: Request a new Docker app to be added to Deployrr
+labels: ["app request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## App Request
+        Want a new app added to Deployrr? Fill out the details below.
+
+  - type: input
+    id: app_name
+    attributes:
+      label: App Name
+      description: Name of the application.
+      placeholder: "e.g. Immich"
+    validations:
+      required: true
+
+  - type: input
+    id: app_website
+    attributes:
+      label: App Website / GitHub
+      description: Link to the app's official website or GitHub repo.
+      placeholder: "https://github.com/..."
+    validations:
+      required: true
+
+  - type: input
+    id: docker_image
+    attributes:
+      label: Docker Image
+      description: Docker Hub or GHCR image link (if available).
+      placeholder: "e.g. ghcr.io/immich-app/immich-server"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: App Description
+      description: Brief description of what the app does and why it would be a good fit for Deployrr.
+      placeholder: "This app does..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What category best fits this app?
+      options:
+        - Media (Streaming / Management)
+        - Downloading (Torrents / Usenet)
+        - Productivity / Office
+        - Home Automation
+        - Monitoring / Dashboards
+        - Networking / DNS
+        - Security / Auth
+        - Database
+        - Development
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other details — special requirements, dependencies, compose examples, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,195 @@
+name: "🐛 Bug Report"
+description: Report a bug or unexpected behavior in Deployrr
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for reporting a bug!
+        Please fill out the sections below so we can reproduce and fix the issue.
+        The more detail you provide, the faster we can help.
+
+  # ── Environment ──────────────────────────────────────────────
+
+  - type: input
+    id: deployrr_version
+    attributes:
+      label: Deployrr Version
+      description: "Which version of Deployrr are you running? Check with: `head -1 deployrr_v*.sh` or the dashboard."
+      placeholder: "e.g. v6.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What OS is your server running?
+      options:
+        - Ubuntu 24.04
+        - Ubuntu 22.04
+        - Ubuntu 20.04
+        - Debian 12 (Bookworm)
+        - Debian 11 (Bullseye)
+        - Linux Mint
+        - Raspberry Pi OS
+        - Proxmox Host
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: input
+    id: os_other
+    attributes:
+      label: Other OS (if applicable)
+      description: "If you selected 'Other' above, specify your OS and version."
+      placeholder: "e.g. Fedora 40, Arch Linux"
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Server Environment
+      description: How is your server running?
+      options:
+        - Bare Metal
+        - Proxmox LXC (Unprivileged)
+        - Proxmox LXC (Privileged)
+        - Proxmox VM
+        - VMware / ESXi VM
+        - VirtualBox VM
+        - Hyper-V VM
+        - WSL2
+        - Cloud VPS (AWS, GCP, etc.)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: CPU Architecture
+      description: "What architecture? Check with: `uname -m`"
+      options:
+        - x86_64 (amd64)
+        - aarch64 (arm64)
+        - armv7l (arm32)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: docker_version
+    attributes:
+      label: Docker Version
+      description: "Check with: `docker --version`"
+      placeholder: "e.g. Docker 27.5.1"
+
+  # ── Bug Scope ────────────────────────────────────────────────
+
+  - type: dropdown
+    id: bug_area
+    attributes:
+      label: Bug Area
+      description: Where does the bug occur?
+      options:
+        - App Installation
+        - App Uninstallation
+        - App Runtime (after install)
+        - Deployrr Setup / Initial Config
+        - Traefik / Reverse Proxy / SSL
+        - Authentication (Authelia / Authentik / OAuth)
+        - Docker Compose Generation
+        - DNS / Domain Configuration
+        - Dashboard
+        - GPU Passthrough
+        - Deployrr Script (general)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected_app
+    attributes:
+      label: Affected App (if applicable)
+      description: "Which app is affected? Include the app name and Docker image version if known."
+      placeholder: "e.g. Plex (linuxserver/plex:1.40.5)"
+
+  - type: dropdown
+    id: gpu
+    attributes:
+      label: GPU Passthrough
+      description: Are you using GPU passthrough?
+      options:
+        - Not applicable
+        - "NVIDIA (nvidia-container-toolkit)"
+        - "AMD (ROCm)"
+        - "Intel (iGPU / QuickSync)"
+        - "Not sure"
+
+  # ── Bug Details ──────────────────────────────────────────────
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: "Describe what happened..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      value: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: |
+        Paste any relevant log output here (terminal output, Docker logs, etc.).
+        This will be automatically formatted as code.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or information that might help.
+
+  # ── Checklist ────────────────────────────────────────────────
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues and this hasn't been reported yet.
+          required: true
+        - label: I am running the latest version of Deployrr.
+          required: false
+        - label: I have checked the [documentation](https://www.simplehomelab.com/deployrr/) for a solution.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Support & Questions
+    url: https://www.simplehomelab.com/discord/
+    about: For general support, setup help, and questions — join our Discord community!
+  - name: 📖 Documentation
+    url: https://www.simplehomelab.com/deployrr/
+    about: Check the official documentation before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: "✨ Feature Request"
+description: Suggest a new feature or improvement for Deployrr
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+        Have an idea to make Deployrr better? We'd love to hear it!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: |
+        What problem does this feature solve? Is this related to a frustration?
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or screenshots.


### PR DESCRIPTION
This restores the issue templates (`bug_report.yml`, `feature_request.yml`, `app_request.yml`, and `config.yml`) that were lost when `v6` was made the default branch or replaced `main`. They have been restored from `main`.