### PR TITLE
Rename secret key in manifest.json

### DIFF
--- a/apps/official/open-webui/manifest.json
+++ b/apps/official/open-webui/manifest.json
@@ -58,7 +58,7 @@
     ],
     "secrets": [
       {
-        "name": "OPENWEBUI_SECRET_KEY",
+        "name": "openwebui_secret_key",
         "description": "Secret key for session encryption",
         "type": "random",
         "length": 32,


### PR DESCRIPTION
Renamed secret key from 'OPENWEBUI_SECRET_KEY' to 'openwebui_secret_key'.  This goes along with change made to open-webui.yml